### PR TITLE
GPG default is 3072 for RSA/RSA

### DIFF
--- a/keyoxidizer.sh
+++ b/keyoxidizer.sh
@@ -9,7 +9,7 @@ generateConfig()
 cat > ./keyoxidizer.config<<EOF
 #%dry-run
 Key-Type: RSA
-Key-Length: 2048
+Key-Length: 3072
 Subkey-Type: RSA
 Name-Real: $keyoxidizer_name
 Name-Email: $keyoxidizer_email


### PR DESCRIPTION
Default keylength for RSA/RSA is 3072 now, this default should probably match.