### PR TITLE
On Mac, sleep doesn't allow the 's' suffix

### DIFF
--- a/keyoxidizer.sh
+++ b/keyoxidizer.sh
@@ -30,7 +30,7 @@ newKey()
    read -p "Enter comment about key: " keyoxidizer_comment
    generateConfig
    echo "You'll now be asked to enter a password to secure the key"
-   sleep 1.5s
+   sleep 1.5
    gpg --batch --generate-key ./keyoxidizer.config
    gpg --fingerprint #clears out meta output
    printFingerPrint $keyoxidizer_email


### PR DESCRIPTION
Works without the 's' everywhere else I'm aware of, off-hand, so I don't think there's any downside to taking it out.